### PR TITLE
Apply JaCoCo-coverage to gradle build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ group 'nl.beehivejava.scriptj'
 version '0.1'
 
 apply plugin: 'java'
+apply plugin: 'jacoco'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -15,3 +16,13 @@ dependencies {
     testCompile group: 'org.powermock', name: 'powermock-api-mockito', version: '1.6.6'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
+
+test {
+    jacoco {
+        append = true
+        destinationFile = file("../build/jacoco/test.exec")
+    }
+
+    reports.junitXml.destination = "../build/test-reports"
+}
+


### PR DESCRIPTION
Added JaCoCo-coverage task to gradle build, and made sure the reports get placed in the correct directories.